### PR TITLE
Update tsconfig to ES2023 and improve configuration

### DIFF
--- a/tooling/tsconfig/README.md
+++ b/tooling/tsconfig/README.md
@@ -1,3 +1,19 @@
 # @priver/tsconfig
 
-Shareable TSConfigs.
+Shared TypeScript configurations for the monorepo.
+
+## Usage
+
+Extend from the appropriate configuration in your `tsconfig.json`:
+
+```json
+{
+  "extends": "@priver/tsconfig"
+}
+```
+
+## Available Configurations
+
+- `@priver/tsconfig` - Base configuration with strict type checking
+- `@priver/tsconfig/react` - React-specific settings (JSX, DOM types)
+- `@priver/tsconfig/vite` - Vite client types

--- a/tooling/tsconfig/package.json
+++ b/tooling/tsconfig/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@priver/tsconfig",
+  "version": "0.0.0",
   "private": true,
   "exports": {
     ".": "./tsconfig.json",

--- a/tooling/tsconfig/tsconfig.json
+++ b/tooling/tsconfig/tsconfig.json
@@ -5,7 +5,6 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -13,7 +12,7 @@
 
     // Modules
     "allowImportingTsExtensions": true,
-    "module": "ES2022",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "resolveJsonModule": false,
 
@@ -22,14 +21,15 @@
     "noEmit": true,
 
     // Interop Constraints
+    "erasableSyntaxOnly": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
     // Language and Environment
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "moduleDetection": "force",
-    "target": "ES2022",
+    "target": "es2023",
 
     // Output Formatting
     "preserveWatchOutput": true,

--- a/tooling/tsconfig/tsconfig.react.json
+++ b/tooling/tsconfig/tsconfig.react.json
@@ -2,6 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["es2022", "dom", "dom.iterable"]
+    "lib": ["es2023", "dom", "dom.iterable"]
   }
 }


### PR DESCRIPTION
- Update target and lib from ES2022 to ES2023 across configurations
- Change module resolution to `"preserve"` for better bundler compatibility
- Add `erasableSyntaxOnly` flag and remove `noPropertyAccessFromIndexSignature`
- Enhance README with usage instructions and configuration options
