### PR TITLE
feat(oxlint-config): remove confusing-browser-globals dependency

### DIFF
--- a/.changeset/clean-globals-rest.md
+++ b/.changeset/clean-globals-rest.md
@@ -1,0 +1,5 @@
+---
+'@priver/oxlint-config': patch
+---
+
+Allow previously restricted browser globals such as `event`, `name`, and `status`.

--- a/packages/oxlint-config/LICENSE.txt
+++ b/packages/oxlint-config/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Mikhail Priver
+Copyright (c) 2026 Mikhail Priver
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -42,12 +42,8 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "build": "pnpm run clean && tsc -b tsconfig.build.json"
   },
-  "dependencies": {
-    "confusing-browser-globals": "^1.0.11"
-  },
   "devDependencies": {
     "@priver/tsconfig": "workspace:*",
-    "@types/confusing-browser-globals": "^1.0.3",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -9,10 +9,6 @@ import { typescriptRules } from './rules/typescript.ts';
 import { unicornRules } from './rules/unicorn.ts';
 
 export const reactConfig = defineConfig({
-  env: {
-    builtin: true,
-    browser: true,
-  },
   plugins: ['import', 'oxc', 'react', 'typescript', 'unicorn'],
   rules: {
     ...eslintRules,
@@ -25,10 +21,6 @@ export const reactConfig = defineConfig({
   overrides: [
     {
       files: ['**/*.config.{ts,mts}'],
-      env: {
-        builtin: true,
-        node: true,
-      },
       plugins: ['import', 'node', 'oxc', 'typescript', 'unicorn'],
       rules: {
         ...eslintRules,
@@ -43,10 +35,6 @@ export const reactConfig = defineConfig({
 });
 
 export const nodeConfig = defineConfig({
-  env: {
-    builtin: true,
-    node: true,
-  },
   plugins: ['import', 'node', 'oxc', 'typescript', 'unicorn'],
   rules: {
     ...eslintRules,

--- a/packages/oxlint-config/src/rules/eslint.ts
+++ b/packages/oxlint-config/src/rules/eslint.ts
@@ -1,4 +1,3 @@
-import confusingBrowserGlobals from 'confusing-browser-globals';
 import type { DummyRuleMap } from 'oxlint';
 
 export const eslintRules = {
@@ -128,7 +127,6 @@ export const eslintRules = {
       message:
         'This API is deprecated. Use https://github.com/sindresorhus/uint8array-extras instead.',
     },
-    ...confusingBrowserGlobals,
   ],
   'no-restricted-imports': 'off',
   'no-restricted-properties': 'off',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,17 +212,10 @@ importers:
         version: 7.0.2
 
   packages/oxlint-config:
-    dependencies:
-      confusing-browser-globals:
-        specifier: ^1.0.11
-        version: 1.0.11
     devDependencies:
       '@priver/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/confusing-browser-globals':
-        specifier: ^1.0.3
-        version: 1.0.3
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -1834,9 +1827,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/confusing-browser-globals@1.0.3':
-    resolution: {integrity: sha512-q+6axdE3RyjrSsy2ONE4UpF89rwOfpoMBP3lqJ+OzLuOeYHwP+o2GITzuleKb1UT3FSYybO8QmeACgyHleu2CA==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2090,9 +2080,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  confusing-browser-globals@1.0.11:
-    resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4269,8 +4256,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/confusing-browser-globals@1.0.3': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -4444,8 +4429,6 @@ snapshots:
   check-error@2.1.3: {}
 
   clsx@2.1.1: {}
-
-  confusing-browser-globals@1.0.11: {}
 
   convert-source-map@2.0.0: {}
 


### PR DESCRIPTION
Allow previously restricted browser globals such as `event`, `name`, and `status`.
