### PR TITLE
fix(oxfmt-config): use default sort import groups

### DIFF
--- a/.changeset/default-import-groups.md
+++ b/.changeset/default-import-groups.md
@@ -1,0 +1,5 @@
+---
+'@priver/oxfmt-config': patch
+---
+
+Use Oxfmt's default import groups when sorting imports.

--- a/packages/oxfmt-config/src/index.ts
+++ b/packages/oxfmt-config/src/index.ts
@@ -1,20 +1,11 @@
 import { defineConfig } from 'oxfmt';
 
 export default defineConfig({
-  singleQuote: true,
-  quoteProps: 'consistent',
-  proseWrap: 'always',
   jsdoc: true,
+  proseWrap: 'always',
+  quoteProps: 'consistent',
+  singleQuote: true,
   sortImports: {
     ignoreCase: false,
-    groups: [
-      'builtin',
-      'external',
-      'internal',
-      'subpath',
-      ['parent', 'sibling', 'index'],
-      'style',
-      'unknown',
-    ],
   },
 });


### PR DESCRIPTION
Use Oxfmt's default import groups when sorting imports.
